### PR TITLE
Distribute rsflex and Rewrite Installation Instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ description = "A super fast system information displayer written in Rust"
 homepage = "https://github.com/curlpipe/rsflex"
 repository = "https://github.com/curlpipe/rsflex"
 license = "MPL-2.0"
-license-file = "LICENSE"
 readme = "README.md"
 keywords = ["flex", "fetch", "rust", "terminal", "command-line"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "rsflex"
 version = "0.2.3"
-authors = ["Curly"]
-edition = "2018"
+authors = ["Curly <11898833+curlpipe@users.noreply.github.com>"]
+description = "A super fast system information displayer written in Rust"
+homepage = "https://github.com/curlpipe/rsflex"
+repository = "https://github.com/curlpipe/rsflex"
+license = "MPL-2.0"
+license-file = "LICENSE"
+readme = "README.md"
+keywords = ["flex", "fetch", "rust", "terminal", "command-line"]
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MPL-2.0"
 license-file = "LICENSE"
 readme = "README.md"
 keywords = ["flex", "fetch", "rust", "terminal", "command-line"]
+edition = "2018"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@
 
 <img src="https://i.postimg.cc/DyPtQ50g/image.png">
 
-A tool similar to that of neofetch and rsfetch that gets system information in the blink of an eye.
+System information tool like neofetch or rsfetch with a fast, beautiful CLI.
 
 ## Configuration
 Rsflex aims to be so simple that you can easily edit the source code!
 In the `src/main.rs` file, you can look towards the bottom of the file and rearrange the functions to your hearts content!
 
 ## Installation
-
-### A) Manual
 
 Dependencies:
 
@@ -28,9 +26,10 @@ On Arch Linux, these can all be installed with:
 yay -S pciutils coreutils xorg-xrandr playerctl ttf-nerd-fonts-symbols curl rustup
 ```
 
-Finally, to install `rsflex` run:
+### A) Cargo
+
 ```
-cargo install --git https://github.com/curlpipe/rsflex
+cargo install rsflex
 ```
 
 ### B) AUR

--- a/README.md
+++ b/README.md
@@ -4,52 +4,60 @@
 
 A tool similar to that of neofetch and rsfetch that gets system information in the blink of an eye.
 
-# Configuration
+## Configuration
 Rsflex aims to be so simple that you can easily edit the source code!
 In the `src/main.rs` file, you can look towards the bottom of the file and rearrange the functions to your hearts content!
 
-# Installation
+## Installation
 
-## Handy AUR package
-rsflex is on the AUR under the name of `rsflex`
-you can install it by doing: `yay -S rsflex`
+### A) Manual
 
-## Buliding rsflex manually
+Dependencies:
 
-Here is what you have to have if you wish to have the full experience of rsflex:
+ - `rustup` - Modern installation of Rust.
+ - `Arch Linux` - Linux Distribution, only Arch supported right now
+ - `ttf-nerd-fonts-symbols` - Nerd fonts to render the fancy icons
+ - `lspci` - Command via `pciutils`
+ - `df` - Command via `coreutils`
+ - `xrandr` - Command via `xorg-xrandr`
+ - `uname` - Command via `coreutils`
+ - `playerctl` - To read MPRIS status
 
- - A modern installation of the rust compiler and cargo `rustup`
- - A linux distrobution at the moment, only Arch Linux is supported :(
- - Nerd fonts to render the fancy icons `ttf-nerd-fonts-symbols`
- - the `lspci` command via `pciutils`
- - the `df` command via `coreutils`
- - the `xrandr` command via `xorg-xrandr`
- - the `uname` command via `coreutils`
- - `playerctl` to read MPRIS status
-
-Here's a handy command to ensure you have everything you need!
+On Arch Linux, these can all be installed with:
 ```
-yay -S pciutils coreutils xorg-xrandr playerctl ttf-nerd-fonts-symbols curl git
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+yay -S pciutils coreutils xorg-xrandr playerctl ttf-nerd-fonts-symbols curl rustup
 ```
 
-And when you want to build it:
+Finally, to install `rsflex` run:
+```
+cargo install --git https://github.com/curlpipe/rsflex
+```
+
+### B) AUR
+
+Rsflex is available on the Arhc User Repository as `rsflex-git`:
+
+```
+yay -S rsflex-git
+```
+
+## Compiling
+
+Building:
 ```
 git clone https://github.com/curlpipe/rsflex
 cd rsflex
 cargo build --release
 ```
 
-To test that it works:
+Running:
 ```
 cargo run --release
 ```
 
-If everything is in order, then you can go ahead and copy it over to your other binaries!
+Install as a binary:
 ```
-sudo cp ./target/release/rsflex /usr/bin/rsflex
+cargo install --path .
 ```
-
-You should now be able to execute `rsflex` wherever you are in your shell!
 
 Have fun! :)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ In the `src/main.rs` file, you can look towards the bottom of the file and rearr
 
 ## Installation
 
+### A) AUR
+
+Rsflex is available on the Arhc User Repository as `rsflex-git`:
+
+```
+yay -S rsflex-git
+```
+
+### B) Cargo
+
 Dependencies:
 
  - `rustup` - Modern installation of Rust.
@@ -23,21 +33,13 @@ Dependencies:
 
 On Arch Linux, these can all be installed with:
 ```
-yay -S pciutils coreutils xorg-xrandr playerctl ttf-nerd-fonts-symbols curl rustup
+yay -S pciutils coreutils xorg-xrandr playerctl ttf-nerd-fonts-symbols cargo
 ```
 
-### A) Cargo
+**Note: These dependencies are only needed if installed via Cargo, they are included automatically with the AUR package above.**
 
 ```
 cargo install rsflex
-```
-
-### B) AUR
-
-Rsflex is available on the Arhc User Repository as `rsflex-git`:
-
-```
-yay -S rsflex-git
 ```
 
 ## Compiling

--- a/src/specs.rs
+++ b/src/specs.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs;
 use std::process::{Command, Stdio};
 
-#[warn(dead_code)]
+#[allow(dead_code)]
 pub fn get_product() -> String {
     match fs::read_to_string("/sys/devices/virtual/dmi/id/product_version") {
         Ok(product) => format!("{} {}", "💻 ", product.trim().to_string()),

--- a/src/specs.rs
+++ b/src/specs.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::fs;
 use std::process::{Command, Stdio};
 
-#[warn(dead_code)]
 pub fn get_product() -> String {
     match fs::read_to_string("/sys/devices/virtual/dmi/id/product_version") {
         Ok(product) => format!("{} {}", "💻 ", product.trim().to_string()),

--- a/src/specs.rs
+++ b/src/specs.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::fs;
 use std::process::{Command, Stdio};
 
+#[warn(dead_code)]
 pub fn get_product() -> String {
     match fs::read_to_string("/sys/devices/virtual/dmi/id/product_version") {
         Ok(product) => format!("{} {}", "💻 ", product.trim().to_string()),


### PR DESCRIPTION
Hi! Here are the changes I have made:

1. Published to the AUR as [`rsflex-git`](https://aur.archlinux.org/packages/rsflex-git).
2. Published to [crates.io](https://crates.io) as [`rsflex`](https://crates.io/crates/rsflex).
3. Rewrite README installation instructions to be clear and concise.
4. Suppress dead code warning in [`src/spec.rs`](src/spec.rs) for a cleaner install.

Great tool! Feel free to make any edits.