### PR TITLE
Minor tweaks and adjustments

### DIFF
--- a/src/specs.rs
+++ b/src/specs.rs
@@ -91,10 +91,10 @@ pub fn get_memory() -> String {
         }
     }
     format!(
-        "{} {:.0}mb / {:.0}mb",
+        "{} {:.1}gb / {:.0}gb",
         "  ",
-        used / 1024.0,
-        total / 1024.0
+        (used / 1024.0) / 1000.0,
+        (total / 1024.0) / 1000.0
     )
 }
 

--- a/src/specs.rs
+++ b/src/specs.rs
@@ -99,7 +99,9 @@ pub fn get_memory() -> String {
 }
 
 pub fn get_resolution() -> String {
-    let cmd = "xrandr --nograb --current";
+    let cmd = "xrandr --nograb --current |\\
+                awk 'match($0,/[0-9]*\\.[0-9]*\\*/) { 
+                    printf $1 \", \" }'";
     let cmd = Command::new("sh")
         .arg("-c")
         .arg(cmd)
@@ -107,11 +109,14 @@ pub fn get_resolution() -> String {
         .output()
         .expect("Error");
     let result = String::from_utf8_lossy(&cmd.stdout);
-    let result = result.split(',').collect::<Vec<&str>>()[1];
+    let mut result = result.replace("x", " x ").trim().to_string();
+    
+    result.truncate(result.len() - 1);
+
     format!(
         "{} {}",
         "  ",
-        result.replace("current ", "").trim().to_string()
+        result
     )
 }
 


### PR DESCRIPTION
### What I've changed

- I've changed the memory unit to gigabytes
- I've converted the memory from MB to GB
- I've changed the way you fetch the resolution, before it combined the total resolution of both monitors into one resolution which isn't very helpful for people like me who have multi-monitor setups. Now, it displays both monitor's resolutions split by commas.

### Screenshot
![image](https://user-images.githubusercontent.com/42723993/97221650-1dbf3b00-17c5-11eb-8c7a-20b5a3cef84b.png)
